### PR TITLE
feat: Login/Signup zustand, auth persistence

### DIFF
--- a/src/components/common/chatbot-search-input/ChatbotSearchInput.tsx
+++ b/src/components/common/chatbot-search-input/ChatbotSearchInput.tsx
@@ -10,9 +10,9 @@ import {
 } from './chatbotSearchInput.css';
 
 type ChatbotSearchInputProps = {
-  chatCompletionsMutation: any;
+  chatCompletionsMutation?: any;
   onImageUpload?: (file: File) => void;
-}
+};
 
 const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletionsMutation, onImageUpload }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -80,7 +80,7 @@ const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletions
     if (file) {
       setSelectedFile(file);
       const reader = new FileReader();
-      reader.onload = (e) => {
+      reader.onload = e => {
         setPreviewImage(e.target?.result as string);
       };
       reader.readAsDataURL(file);
@@ -110,7 +110,7 @@ const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletions
                 width: '30px',
                 height: '30px',
                 objectFit: 'cover',
-                marginRight: '5px'
+                marginRight: '5px',
               }}
             />
             <button
@@ -119,7 +119,7 @@ const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletions
                 background: 'none',
                 border: 'none',
                 cursor: 'pointer',
-                fontSize: '16px'
+                fontSize: '16px',
               }}
             >
               ×
@@ -134,7 +134,7 @@ const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletions
           onChange={handleInputChange}
           onCompositionStart={() => setIsComposing(true)}
           onCompositionEnd={() => setIsComposing(false)}
-          placeholder={selectedFile ? "이미지가 첨부되었습니다" : "궁금한 신발 정보 물어보세요!"}
+          placeholder={selectedFile ? '이미지가 첨부되었습니다' : '궁금한 신발 정보 물어보세요!'}
           style={{ paddingLeft: previewImage ? '80px' : '10px' }}
           onKeyDown={handleKeyDown}
           disabled={selectedFile !== null}
@@ -143,13 +143,7 @@ const ChatbotSearchInput: React.FC<ChatbotSearchInputProps> = ({ chatCompletions
           <img src={upload} alt="upload" />
         </button>
       </div>
-      <input
-        ref={fileInputRef}
-        type="file"
-        style={{ display: 'none' }}
-        accept="image/*"
-        onChange={handleFileChange}
-      />
+      <input ref={fileInputRef} type="file" style={{ display: 'none' }} accept="image/*" onChange={handleFileChange} />
     </div>
   );
 };

--- a/src/components/login/find/FindEmail.tsx
+++ b/src/components/login/find/FindEmail.tsx
@@ -6,9 +6,9 @@ import { accountFindBox, accountFindButton } from '../emaillogin/emailLogin.css'
 import { useState } from 'react';
 import SignUpInput from '../../signup/infoInput/signupinput/SignUpInput';
 import { foundResultStyle, fullContainer } from '../login.css';
-import { db } from '../../../firebase/firebase';
+import { USER_COLLECTION } from '../../../firebase/firebase';
 import { back_arrow } from '../../../assets/assets';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { getDocs, query, where } from 'firebase/firestore';
 import SignUpDateSelect from '../../signup/infoInput/signupdateselect/SignUpDateSelect';
 import SignUpSelect from '../../signup/infoInput/signupselect/SignUpSelect';
 import { responsiveBox } from '../../../styles/responsive.css';
@@ -51,42 +51,19 @@ const FindEmail = () => {
     return newErrors;
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-
-    if (name === 'year' || name === 'month' || name === 'day') {
+  const handleChange = (field: string, value: string) => {
+    if (field === 'year' || field === 'month' || field === 'day') {
       setFormData(prev => ({
         ...prev,
         birthDate: {
           ...prev.birthDate,
-          [name]: value,
+          [field]: value,
         },
-      }));
-
-      const updatedErrors = validate({
-        ...formData,
-        birthDate: {
-          ...formData.birthDate,
-          [name]: value,
-        },
-      });
-      setErrors(prev => ({
-        ...prev,
-        birthDate: updatedErrors.birthDate,
       }));
     } else {
       setFormData(prev => ({
         ...prev,
-        [name]: value,
-      }));
-
-      const updatedErrors = validate({
-        ...formData,
-        [name]: value,
-      });
-      setErrors(prev => ({
-        ...prev,
-        [name]: updatedErrors[name],
+        [field]: value,
       }));
     }
   };
@@ -94,8 +71,8 @@ const FindEmail = () => {
   const [foundEmail, setFoundEmail] = useState<string | null>(null);
   const [error, setError] = useState<string>('');
 
-  const handleFindEmail = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleFindEmail = async () => {
+    setErrors({});
 
     const errors = validate(formData);
     if (Object.keys(errors).length) {
@@ -104,8 +81,9 @@ const FindEmail = () => {
     }
 
     try {
+      //일치하는 사용자 정보 찾기
       const userQuery = query(
-        collection(db, 'users'),
+        USER_COLLECTION,
         where('userName', '==', formData.userName),
         where('gender', '==', formData.gender),
         where('birthDate.year', '==', formData.birthDate.year),
@@ -126,7 +104,7 @@ const FindEmail = () => {
       }
     } catch (error) {
       console.error('이메일 찾기 오류:', error);
-      setError('이메일 찾기에 실패했습니다. 다시 시도해 주세요.');
+      setError('다시 시도해 주세요.');
     }
   };
 
@@ -153,7 +131,7 @@ const FindEmail = () => {
                   id="userName"
                   placeholder="이름을 입력해 주세요"
                   value={formData.userName}
-                  onChange={handleChange}
+                  onChange={e => handleChange('userName', e.target.value)}
                 />
                 {errors.userName && <div className={errorMessage}>{errors.userName}</div>}
               </div>
@@ -168,7 +146,7 @@ const FindEmail = () => {
                     { value: 'female', label: '여성' },
                   ]}
                   value={formData.gender}
-                  onChange={handleChange}
+                  onChange={e => handleChange('gender', e.target.value)}
                 />
                 {errors.gender && <div className={errorMessage}>{errors.gender}</div>}
               </div>
@@ -179,9 +157,7 @@ const FindEmail = () => {
               </div>
 
               <div className={submitbuttonContainer}>
-                <form onSubmit={handleFindEmail}>
-                  <Button text="이메일 찾기" />
-                </form>
+                <Button text="이메일 찾기" onClick={handleFindEmail} />
               </div>
 
               {foundEmail && <div className={foundResultStyle}>{foundEmail}</div>}

--- a/src/components/login/find/FindPassword.tsx
+++ b/src/components/login/find/FindPassword.tsx
@@ -47,25 +47,14 @@ const FindPassword = () => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
-    setFormData(prev => {
-      const updatedFormData = {
-        ...prev,
-        [name]: value,
-      };
-
-      const updatedErrors = validate(updatedFormData);
-
-      setErrors(prevErrors => ({
-        ...prevErrors,
-        [name as keyof FormErrors]: updatedErrors[name as keyof FormErrors],
-      }));
-
-      return updatedFormData;
-    });
+    setFormData(prev => ({
+      ...prev,
+      [name]: value,
+    }));
   };
 
-  const handleFindPassword = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleFindPassword = async () => {
+    setErrors({});
 
     const errors = validate(formData);
     if (Object.keys(errors).length) {
@@ -94,7 +83,7 @@ const FindPassword = () => {
       }
     } catch (error) {
       console.error('비밀번호 찾기 오류:', error);
-      setError('비밀번호 찾기에 실패했습니다. 다시 시도해 주세요.');
+      setError('다시 시도해 주세요.');
       setSuccessMessage(null);
     }
   };
@@ -114,37 +103,35 @@ const FindPassword = () => {
           <div>
             <Header imageSrc={back_arrow} alt="back arrow" title="비밀번호 찾기" />
             <div className={signupFormContainer} style={{ marginTop: '20px' }}>
-              <form onSubmit={handleFindPassword}>
-                <div>
-                  <SignUpInput
-                    label="이름"
-                    type="text"
-                    name="userName"
-                    id="userName"
-                    placeholder="이름을 입력해 주세요"
-                    value={formData.userName}
-                    onChange={handleChange}
-                  />
-                  {errors.userName && <div className={errorMessage}>{errors.userName}</div>}
-                </div>
+              <div>
+                <SignUpInput
+                  label="이름"
+                  type="text"
+                  name="userName"
+                  id="userName"
+                  placeholder="이름을 입력해 주세요"
+                  value={formData.userName}
+                  onChange={handleChange}
+                />
+                {errors.userName && <div className={errorMessage}>{errors.userName}</div>}
+              </div>
 
-                <div className={signupFormGap}>
-                  <SignUpInput
-                    label="이메일"
-                    type="email"
-                    name="userEmail"
-                    id="userEmail"
-                    placeholder="이메일을 입력해 주세요"
-                    value={formData.userEmail}
-                    onChange={handleChange}
-                  />
-                  {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
-                </div>
+              <div className={signupFormGap}>
+                <SignUpInput
+                  label="이메일"
+                  type="email"
+                  name="userEmail"
+                  id="userEmail"
+                  placeholder="이메일을 입력해 주세요"
+                  value={formData.userEmail}
+                  onChange={handleChange}
+                />
+                {errors.userEmail && <div className={errorMessage}>{errors.userEmail}</div>}
+              </div>
 
-                <div className={submitbuttonContainer}>
-                  <Button text="비밀번호 찾기" />
-                </div>
-              </form>
+              <div className={submitbuttonContainer}>
+                <Button text="비밀번호 찾기" onClick={handleFindPassword} />
+              </div>
 
               {successMessage && <div className={foundResultStyle}>{successMessage}</div>}
               {error && <div className={foundResultStyle}>{error}</div>}

--- a/src/components/login/login.css.ts
+++ b/src/components/login/login.css.ts
@@ -57,4 +57,5 @@ export const foundResultStyle = style({
   lineHeight: '20px',
   letterSpacing: '-0.003em',
   marginBottom: '34px',
+  textAlign: 'center',
 });

--- a/src/components/onboarding/OnBoarding.tsx
+++ b/src/components/onboarding/OnBoarding.tsx
@@ -2,16 +2,80 @@ import { useNavigate } from 'react-router-dom';
 import { onboarding1, onboarding2 } from '../../assets/assets';
 import Button from '../common/button/Button';
 import { buttonDiv, container, descP, slide, slide0, slide1, slidesWrapper } from './onboarding.css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { responsiveBox } from '../../styles/responsive.css';
+import useUserStore from '../../stores/useUserStore';
+import { TUser } from '../../types/user';
+import { browserLocalPersistence, onAuthStateChanged, setPersistence } from 'firebase/auth';
+import { auth, db } from '../../firebase/firebase';
+import { doc, getDoc } from 'firebase/firestore';
 
 const OnBoarding = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
   const navigate = useNavigate();
 
-  const handlePageMove = () => {
-    navigate('/login');
+  //로그인 지속성
+  const setUser = useUserStore(state => state.setUser);
+  const clearUser = useUserStore(state => state.clearUser);
+
+  useEffect(() => {
+    //로그인 상태에 따라 특정 작업을 수행
+    const monitorAuthState = () => {
+      setPersistence(auth, browserLocalPersistence) //사용자가 브라우저를 닫아도 로그인 상태 유지
+        .then(() => {
+          onAuthStateChanged(auth, async user => {
+            if (user) {
+              //Firestore에서 사용자 정보 존재 유무를 uid로 조회
+              const userDocRef = doc(db, 'users', user.uid);
+              const userDoc = await getDoc(userDocRef);
+
+              if (userDoc.exists()) {
+                const userData: TUser = {
+                  ...userDoc.data(),
+                };
+                setUser(userData); //zustand에 로그인한 사용자 정보를 userData로 저장
+                console.log('현재 로그인한 사용자:', userData); //로그인되어 있는 경우
+              } else {
+                clearUser(); //상태 초기화
+                console.log('로그인한 사용자 정보가 없는 상태'); //인증은 되었으나 Firestore에는 사용자 등록이 되어있지 않은 경우 (로그인되어 있는 경우로 판단)
+              }
+            } else {
+              clearUser(); //상태 초기화
+              console.log('로그아웃 상태'); //로그인되어 있지 않은 경우
+            }
+          });
+        })
+        .catch(error => {
+          console.error('로그인 지속성 실패:', error);
+        });
+    };
+
+    monitorAuthState();
+  }, [navigate, setUser, clearUser]);
+
+  const handlePageMove = async () => {
+    const currentUser = auth.currentUser;
+
+    if (!currentUser) {
+      navigate('/login'); // 로그인되어 있지 않은 경우
+    } else {
+      //Firestore에서 사용자 정보 존재 유무를 uid로 조회
+      const userDocRef = doc(db, 'users', currentUser.uid);
+      const userDoc = await getDoc(userDocRef);
+
+      if (userDoc.exists()) {
+        navigate('/hello'); //로그인되어 있는 경우
+      } else {
+        await currentUser.delete(); //사용자 인증 데이터 삭제
+        console.log('사용자 인증 데이터 삭제');
+        navigate('/login'); //인증은 되었으나 Firestore에는 사용자 등록이 되어있지 않은 경우
+      }
+    }
   };
+
+  // const handlePageMove = () => {
+  //   navigate('/login');
+  // };
 
   const handleNextSlide = () => {
     if (currentSlide < 1) {

--- a/src/components/signup/infoInput/GoogleSignUpPlus.tsx
+++ b/src/components/signup/infoInput/GoogleSignUpPlus.tsx
@@ -8,111 +8,49 @@ import { hamburger_menu } from '../../../assets/assets';
 import { fullContainer } from '../../login/login.css';
 import { errorMessage, signupFormContainer, signupFormGap, submitbuttonContainer } from '../signup.css';
 import { useNavigate } from 'react-router-dom';
-import { USER_COLLECTION } from '../../../firebase/firebase';
-import { doc, updateDoc } from 'firebase/firestore';
 import { responsiveBox } from '../../../styles/responsive.css';
 import ToastMessage from '../../toastmessage/toastMessage';
+import useUserStore from '../../../stores/useUserStore';
 
 const GoogleSignUpPlus = () => {
-  type FormErrors = {
-    gender?: string;
-    birthDate?: string;
-    [key: string]: string | undefined;
-  };
+  const navigate = useNavigate();
+  const { setUser, user } = useUserStore();
 
-  type FormData = {
-    gender: string;
-    birthDate: {
-      year: string;
-      month: string;
-      day: string;
-    };
-  };
+  const [birthDate, setBirthDate] = useState({ year: '', month: '', day: '' });
+  const [gender, setGender] = useState('');
 
-  const [errors, setErrors] = useState<FormErrors>({});
-  const [formData, setFormData] = useState<FormData>({
-    gender: '',
-    birthDate: {
-      year: '',
-      month: '',
-      day: '',
-    },
-  });
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [toastMessage, setToastMessage] = useState<{ message: string; duration: number } | null>(null);
 
-  const validate = (data: FormData): FormErrors => {
-    const newErrors: FormErrors = {};
-    if (!data.gender) newErrors.gender = '성별을 선택해주세요';
-    const { year, month, day } = data.birthDate;
-    if (!year || !month || !day) newErrors.birthDate = '생년월일을 입력해주세요';
+  const validate = () => {
+    const newErrors: { [key: string]: string } = {};
+
+    if (!birthDate.year || !birthDate.month || !birthDate.day) newErrors.birthDate = '생년월일을 입력해 주세요';
+    if (!gender) newErrors.gender = '성별을 선택해 주세요';
     return newErrors;
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-
-    if (name === 'year' || name === 'month' || name === 'day') {
-      setFormData(prev => ({
-        ...prev,
-        birthDate: {
-          ...prev.birthDate,
-          [name]: value,
-        },
-      }));
-
-      const updatedErrors = validate({
-        ...formData,
-        birthDate: {
-          ...formData.birthDate,
-          [name]: value,
-        },
-      });
-      setErrors(prev => ({
-        ...prev,
-        birthDate: updatedErrors.birthDate,
-      }));
-    } else {
-      setFormData(prev => ({
-        ...prev,
-        [name]: value,
-      }));
-
-      const updatedErrors = validate({
-        ...formData,
-        [name]: value,
-      });
-      setErrors(prev => ({
-        ...prev,
-        [name]: updatedErrors[name],
-      }));
-    }
-  };
-
-  const navigate = useNavigate();
-  //localStorage에서 사용자 ID 가져오기
-  const userUID = localStorage.getItem('userUID');
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const validationErrors = validate(formData);
+  const handleNextPage = () => {
+    const validationErrors = validate();
     setErrors(validationErrors);
 
     if (Object.keys(validationErrors).length === 0) {
       try {
-        if (userUID) {
-          //USER Collection에 데이터 저장
-          const userDocRef = doc(USER_COLLECTION, userUID); //사용자 ID로 문서 참조
-          await updateDoc(userDocRef, {
-            gender: formData.gender,
-            birthDate: formData.birthDate,
-          });
+        //zustand에 사용자 정보 업데이트
+        const updatedGoogleUser = {
+          ...user,
+          birthDate: {
+            year: birthDate.year,
+            month: birthDate.month,
+            day: birthDate.day,
+          },
+          gender: gender,
+        };
+        setUser(updatedGoogleUser);
 
-          navigate('/signupsize');
-        } else {
-          setToastMessage({ message: '순서대로 회원가입을 진행해주세요.', duration: 3000 });
-        }
-      } catch {
+        navigate('/signupsize');
+      } catch (error) {
+        console.error('상태 업데이트 실패:', error);
         setToastMessage({ message: '다시 시도해 주세요.', duration: 3000 });
       }
     }
@@ -152,8 +90,8 @@ const GoogleSignUpPlus = () => {
                       { value: 'male', label: '남성' },
                       { value: 'female', label: '여성' },
                     ]}
-                    value={formData.gender}
-                    onChange={handleChange}
+                    value={gender}
+                    onChange={e => setGender(e.target.value)}
                   />
                   {errors.gender && <div className={errorMessage}>{errors.gender}</div>}
                 </div>
@@ -162,19 +100,17 @@ const GoogleSignUpPlus = () => {
                   <DateSelect
                     label="생년월일"
                     value={{
-                      year: formData.birthDate.year,
-                      month: formData.birthDate.month,
-                      day: formData.birthDate.day,
+                      year: birthDate.year,
+                      month: birthDate.month,
+                      day: birthDate.day,
                     }}
-                    onChange={handleChange}
+                    onChange={(field, value) => setBirthDate(prev => ({ ...prev, [field]: value }))}
                   />
                   {errors.birthDate && <div className={errorMessage}>{errors.birthDate}</div>}
                 </div>
 
                 <div className={submitbuttonContainer}>
-                  <form onSubmit={handleSubmit}>
-                    <Button text="다음" />
-                  </form>
+                  <Button text="다음" onClick={handleNextPage} />
                 </div>
               </div>
             </Modal>

--- a/src/components/signup/infoInput/signupdateselect/SignUpDateSelect.tsx
+++ b/src/components/signup/infoInput/signupdateselect/SignUpDateSelect.tsx
@@ -8,7 +8,7 @@ import {
 type TDateSelect = {
   label: string;
   value: { year: string; month: string; day: string };
-  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onChange: (field: string, value: string) => void;
 };
 
 const SignUpDateSelect = ({ label, value, onChange }: TDateSelect) => {
@@ -45,15 +45,33 @@ const SignUpDateSelect = ({ label, value, onChange }: TDateSelect) => {
         {label}
       </label>
       <div className={dateSelectHorizon}>
-        <select id="year" name="year" className={dateSelect} value={value.year} onChange={onChange}>
+        <select
+          id="year"
+          name="year"
+          className={dateSelect}
+          value={value.year}
+          onChange={e => onChange('year', e.target.value)}
+        >
           <option value="">년</option>
           {years}
         </select>
-        <select id="month" name="month" className={dateSelect} value={value.month} onChange={onChange}>
+        <select
+          id="month"
+          name="month"
+          className={dateSelect}
+          value={value.month}
+          onChange={e => onChange('month', e.target.value)}
+        >
           <option value="">월</option>
           {months}
         </select>
-        <select id="day" name="day" className={dateSelect} value={value.day} onChange={onChange}>
+        <select
+          id="day"
+          name="day"
+          className={dateSelect}
+          value={value.day}
+          onChange={e => onChange('day', e.target.value)}
+        >
           <option value="">일</option>
           {days}
         </select>

--- a/src/components/signup/infoInput/signupinput/SignUpInput.tsx
+++ b/src/components/signup/infoInput/signupinput/SignUpInput.tsx
@@ -32,7 +32,7 @@ const SignUpInput = ({
         placeholder={placeholder}
         value={value}
         onChange={onChange}
-      // required
+        onFocus={e => e.target.select()}
       />
     </div>
   );

--- a/src/services/fetchUserDatasService.ts
+++ b/src/services/fetchUserDatasService.ts
@@ -1,0 +1,33 @@
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase/firebase';
+import { TUser } from '../types/user';
+
+// Firestore에서 사용자 데이터를 가져오는 함수
+export const fetchUserDatas = async (uid: string): Promise<TUser | null> => {
+  try {
+    // 'users' 컬렉션 참조
+    const USER_COLLECTION = collection(db, 'users');
+    // uid가 일치하는 문서를 쿼리
+    const userQuery = query(USER_COLLECTION, where('uid', '==', uid));
+    // 쿼리 실행하여 문서 가져오기
+    const userSnapshot = await getDocs(userQuery);
+
+    // 사용자 데이터를 저장할 배열
+    const usersData: TUser[] = [];
+    userSnapshot.forEach(doc => {
+      const data = doc.data() as TUser; // TUser 타입으로 데이터 캐스팅
+      usersData.push(data);
+    });
+
+    // 첫 번째 사용자 데이터를 반환 (해당하는 uid가 있는 경우)
+    if (usersData.length > 0) {
+      return usersData[0]; // 첫 번째 사용자 데이터 반환
+    } else {
+      console.log('사용자 데이터를 찾을 수 없습니다.');
+      return null;
+    }
+  } catch (error) {
+    console.error('사용자 데이터를 가져오는 중 오류 발생: ', error);
+    return null;
+  }
+};

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { TUser } from '../types/user';
+import { persist } from 'zustand/middleware';
+
+type userStore = {
+  user: TUser | null;
+  setUser: (user: TUser) => void;
+  clearUser: () => void;
+};
+
+const useUserStore = create(
+  persist<userStore>(
+    set => ({
+      user: null,
+      setUser: user => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'userLocalStorage', //localStorage에 저장될 키 이름
+      getStorage: () => localStorage, //localStorage를 사용
+    }
+  )
+);
+
+export default useUserStore;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,0 +1,16 @@
+export type TUser = {
+  email?: string;
+  // password?: string;
+  userName?: string;
+  gender?: string;
+  birthDate?: {
+    year: string;
+    month: string;
+    day: string;
+  };
+  shoeSize?: number;
+  sizeType?: string;
+  uid?: string; //회원가입 시 자동 생성
+  // isGoogle?: boolean;
+  // signupStep?: string;
+};


### PR DESCRIPTION
### 🌎Pull Request
> feat: Login/Signup zustand, auth persistence

### #️⃣연관되어 있는 이슈
> #110 

### PR Type
  > - [x] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [ ] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [x] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [x] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [ ] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

### Description
> * 유효성 검사 실시간 검증 삭제 (버튼 누르면 그 때 검증)
> * zustand로 회원가입 상태 관리 (회원가입 페이지 이동하면서 상태에 저장해뒀다가 마지막에 가입 완료 누르면 파이어스토어에 사용자 등록)
> * 온보딩 페이지에 로그인 지속성 로직 추가 (로그아웃 하지 않는 한 사용자가 브라우저를 닫아도 로그인 상태 유지, 로그인 여부에 따라 온보딩 후 이동 페이지 상이) 
-> 제가 테스트 해보기엔 잘 되는 것 같은데 혹시 이상 있으면 말씀해주세요...
> * zustand에서 가져온 user 데이터 사용하여 /hello 페이지에 로그인한 사용자 이름 반영
-> 하윤님 마이페이지 코드 참고했습니다...

### Screenshot
> * 특별한 style 변화 x

### Discussion
> * 회원가입 따로 페이지가 아니라 로그인 화면에서 모달 올라오게 해야하는 건지??
> * zustand에서 가져온 user 데이터 사용할 때 이런 식으로 했습니다...
```typescript
const 컴포넌트 = () => {
//...
  const { user, setUser } = useUserStore();

  useEffect(() => {
    const auth = getAuth();
    const unsubscribe = onAuthStateChanged(auth, async user => {
      if (user) {
        const uid = user.uid;
        //상태에 user 데이터가 없을 때만 fetchUserDatas(Firestore에서 사용자 데이터를 가져오는 함수) 호출
        if (!user) {
          const userData = await fetchUserDatas(uid);
          if (userData) {
            setUser(userData);
          }
        }
      } else {
        console.log('로그인한 사용자가 없습니다.');
      }
    });

    return () => unsubscribe();
  }, [setUser]);
//...
    
//사용할 때 
{user?.userName}
```