### PR TITLE
refactor: 사이드메뉴 스캘래톤 생성, 이미지 검색시 포맷,리사이징

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>perfitt</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-image-file-resizer": "^0.4.8",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.26.1",
     "zustand": "^4.5.5"

--- a/src/components/chatbot/product-filter/productFilter.css.ts
+++ b/src/components/chatbot/product-filter/productFilter.css.ts
@@ -40,12 +40,13 @@ export const productRecommendFiltering = style({
 })
 
 export const productRecommendWrapper = style({
-  height: '455px', // 또는 원하는 고정 높이
+  height: '700px', // 또는 원하는 고정 높이
   overflowY: 'auto',
   
 });
 
 export const productRecommend = style({
+  width:'100%',
   display: 'grid',
   gridTemplateColumns: '1fr 1fr', 
   gap: '10px',

--- a/src/components/chatbot/product-recommendation-preview/ProductRecommendationPreview.tsx
+++ b/src/components/chatbot/product-recommendation-preview/ProductRecommendationPreview.tsx
@@ -65,12 +65,12 @@ const ProductRecommendationPreview = ({ products = [], shareId, onMoreClick }: P
           ) : (
             <li>상품이 없습니다.</li> // 상품이 없을 때 보여줄 메시지
           )}
-          <div onClick={handleOpenModal}>
+          <li onClick={handleOpenModal}>
             <div className={productRecommendPreviewMore}>
-              <img src={arrow_right} className={productRecommendPreviewMoreIcon} />
+              <img src={arrow_right} className={productRecommendPreviewMoreIcon} alt='more_button' />
               <p style={{ fontSize: '9px', marginTop: '6px' }}>더보기</p>
             </div>
-          </div>
+          </li>
         </motion.ul>
         <div className={productRecommendPreviewIconWrap}>
           <img src={export_icon} alt="" className={productRecommendPreviewIcon} onClick={handleOpenShareModal} />

--- a/src/components/common/product-recommendation-card/ProductRecommendationCard.tsx
+++ b/src/components/common/product-recommendation-card/ProductRecommendationCard.tsx
@@ -36,7 +36,7 @@ const ProductRecommendationCard = ({ product }: ProductRecommendationCardProps) 
         {/* Thumbnail */}
         <div className={productRecommendationThumbnail}>
           <div className={productRecommendationThumbnailContainer}>
-            <img src={product?.image} />
+            <img src={product?.image} alt={product?.brand} loading='lazy' />
           </div>
           <div className={heartIconBox} onClick={(e) => {
             e.stopPropagation();

--- a/src/components/empty-shoes-room/EmptyShoesRoom.tsx
+++ b/src/components/empty-shoes-room/EmptyShoesRoom.tsx
@@ -1,10 +1,13 @@
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
+import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { collection, query, getDocs, orderBy, where } from 'firebase/firestore';
 import { noshoes, plus } from '../../assets/assets';
+import { db } from '../../firebase/firebase';
+import LoadingPage from '../../pages/loading-page/loadingPage';
+import { ShoesList, UserData } from '../../types/shoesroom';
 import Button from '../common/button/Button';
-import Header from './header/Header';
-import UserProfile from './user-profile/UserProfile';
+import ToastMessage from '../toastmessage/toastMessage';
 import {
   buttonDiv,
   buttonImage,
@@ -18,11 +21,8 @@ import {
   select,
   shoesdiv,
 } from './emptyshoesroom.css';
-import { db } from '../../firebase/firebase';
-import ToastMessage from '../toastmessage/toastMessage';
-import { getAuth, onAuthStateChanged } from 'firebase/auth';
-import { ShoesList, UserData } from '../../types/shoesroom';
-import LoadingPage from '../../pages/loading-page/loadingPage';
+import Header from './header/Header';
+import UserProfile from './user-profile/UserProfile';
 
 const EmptyShoesRoom = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -139,7 +139,7 @@ const EmptyShoesRoom = () => {
     <>
       <div className={container}>
         {toastMessage && <ToastMessage message={toastMessage} duration={3000} />}
-        <Header title="신발장" customNavigate={() => navigate('/hello')} />
+        <Header title="신발장" customNavigate={() => navigate('/chat')} />
         <UserProfile userData={userData} />
         {shoesList.length > 0 ? (
           <>

--- a/src/components/foot-info/FootInfo.tsx
+++ b/src/components/foot-info/FootInfo.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { foot_loading } from '../../assets/assets';
 import Button from '../common/button/Button';
 import Header from '../empty-shoes-room/header/Header';
-import { bigP, buttonDiv, container, imgDiv, smallP } from './foot-info.css';
+import { bigP, buttonDiv, container, contentContainer, footInfoWrap, imgDiv, smallP } from './foot-info.css';
 
 const FootInfo = () => {
   useEffect(() => {
@@ -15,19 +15,21 @@ const FootInfo = () => {
   }, []);
 
   return (
-    <>
-      <div className={container}>
-        <Header title="내 발 정보" />
-        <div className={imgDiv}>
-          <img src={foot_loading} alt="foot_loading" style={{ width: '284px' }} />
-        </div>
-        <p className={bigP}>발 정보가 아직 없습니다</p>
-        <p className={smallP}>발 촬영으로 내 발 리포트를 받아보세요.</p>
-        <div className={buttonDiv}>
-          <Button text="내 발 측정하기" id="perfitt_size_button" />
+    <div className={container}>
+      <Header title="내 발 정보" />
+      <div className={contentContainer}>
+        <div className={footInfoWrap}>
+          <div className={imgDiv}>
+            <img src={foot_loading} alt="foot_loading" />
+          </div>
+          <p className={bigP}>발 정보가 아직 없습니다</p>
+          <p className={smallP}>발 촬영으로 내 발 리포트를 받아보세요.</p>
+          <div className={buttonDiv}>
+            <Button text="내 발 측정하기" id="perfitt_size_button" />
+          </div>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/foot-info/foot-info.css.ts
+++ b/src/components/foot-info/foot-info.css.ts
@@ -3,14 +3,25 @@ import { style } from '@vanilla-extract/css';
 export const container = style({
   display: 'flex',
   flexDirection: 'column',
-  justifyContent: 'flex-start',
-  alignItems: 'center',
-  minHeight: '100%',
-  position: 'relative',
+  minHeight: '100vh',
+  height: '100%',
 });
 
+export const contentContainer = style({
+  flexGrow: 1,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+export const footInfoWrap = style({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
+})
 export const imgDiv = style({
-  marginTop: '135px',
+  width: '284px',
+  height: 'auto',
 });
 
 export const bigP = style({

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -44,7 +44,7 @@ const Login = () => {
         };
         setUser(userData); //userData를 zustand에 저장
         // console.log('로그인한 사용자:', userData);
-        navigate('/hello'); //기존 사용자: 로그인 성공 후 /hello(로그인 후 첫 화면) 페이지로 이동
+        navigate('/chat'); //기존 사용자: 로그인 성공 후 /hello(로그인 후 첫 화면) 페이지로 이동
       } else {
         const newGoogleUser = {
           uid: googleUser.uid, //구글 회원가입 시 자동 생성된 uid 저장

--- a/src/components/login/emaillogin/EmailLogin.tsx
+++ b/src/components/login/emaillogin/EmailLogin.tsx
@@ -1,4 +1,5 @@
 import { deleteUser, signInWithEmailAndPassword } from 'firebase/auth';
+import { doc, getDoc, getFirestore } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { back_arrow } from '../../../assets/assets';
@@ -16,7 +17,6 @@ import SignUpSizeModal from '../../signup/sizeinput/SignUpSizeModal';
 import ToastMessage from '../../toastmessage/toastMessage';
 import { fullContainer } from '../login.css';
 import { accountFindBox, accountFindButton } from './emailLogin.css';
-import { doc, getDoc, getFirestore } from 'firebase/firestore';
 
 const EmailLogin = () => {
   type FormData = {
@@ -83,7 +83,7 @@ const EmailLogin = () => {
             setUser(userData); //userData를 zustand에 저장
             // console.log('로그인한 사용자:', userData);
             const newChatId = await handleNewChat();
-            navigate(`/hello/${newChatId}`); //로그인 성공 시 이동
+            navigate(`/chat/${newChatId}`); //로그인 성공 시 이동
           } else {
             //인증은 되었으나 Firestore에는 사용자 등록이 되어있지 않은 경우
             await deleteUser(user); //사용자 인증 데이터 삭제

--- a/src/components/login/login-hello/LoginHello.tsx
+++ b/src/components/login/login-hello/LoginHello.tsx
@@ -400,7 +400,7 @@ const LoginHello = () => {
         }
 
         {chatHistory.length > 0 && (
-          <Modal height="70vh" initialHeight="125px" >
+          <Modal height="100vh" initialHeight="125px" >
             {selectedBrand ? (
               <BrandPLP />
             ) : showProductRecommendation ? (

--- a/src/components/login/login-hello/loginHello.css.ts
+++ b/src/components/login/login-hello/loginHello.css.ts
@@ -30,6 +30,7 @@ export const loginHelloContainer = style({
   display: 'flex',
   flexDirection: 'column',
   padding: '0 16px',
+  marginBottom:'30px'
   
   // paddingBottom: '150px',
   //  '@media': {

--- a/src/components/mypage/size-recommendation-card/SizeRecommendationCard.tsx
+++ b/src/components/mypage/size-recommendation-card/SizeRecommendationCard.tsx
@@ -66,7 +66,7 @@ const SizeRecommendationCard = ({
     >
       <div className={sizeRecommendationThumbnail}>
         <div className={sizeRecommendationThumbnailContainer}>
-          <img src={product.image} alt={product.modelName} />
+          <img src={product.image} alt={product.modelName} loading='lazy' />
         </div>
         <div className={sizeRecommendationBadge}>
           <p className={sizeRecommendationBadgeTag}>{product?.sizeRecommend} 추천</p>

--- a/src/components/onboarding/OnBoarding.tsx
+++ b/src/components/onboarding/OnBoarding.tsx
@@ -57,7 +57,7 @@ const OnBoarding = () => {
       const userDoc = await getDoc(userDocRef);
 
       if (userDoc.exists()) {
-        navigate('/hello'); //로그인되어 있는 경우
+        navigate('/chat'); //로그인되어 있는 경우
       } else {
         await currentUser.delete(); //사용자 인증 데이터 삭제
         // console.log('사용자 인증 데이터 삭제');

--- a/src/components/sidemenu-skeleton/SideMenuSkeleton.tsx
+++ b/src/components/sidemenu-skeleton/SideMenuSkeleton.tsx
@@ -1,0 +1,33 @@
+import { motion } from 'framer-motion';
+import { skeletonWrap } from './sidemenuSkeleton.css';
+
+const SkeletonItem = ({ width }: { width: string }) => (
+  <motion.span
+    style={{
+      width,
+      height: '20px',
+      borderRadius: '4px',
+      backgroundColor: '#e0e0e0',
+    }}
+    animate={{
+      backgroundColor: ['#e0e0e0', '#f0f0f0', '#e0e0e0'],
+    }}
+    transition={{
+      duration: 1.5,
+      repeat: Infinity,
+      ease: 'linear',
+    }}
+  />
+);
+
+const SideMenuSkeleton = () => {
+  return (
+    <div className={skeletonWrap}>
+      <SkeletonItem width="100%" />
+      <SkeletonItem width="80%" />
+      <SkeletonItem width="60%" />
+    </div>
+  );
+};
+
+export default SideMenuSkeleton;

--- a/src/components/sidemenu-skeleton/sidemenuSkeleton.css.ts
+++ b/src/components/sidemenu-skeleton/sidemenuSkeleton.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+export const skeletonWrap = style({
+  width: '100%',
+  height: '210px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});

--- a/src/components/sidemenu/SideMenu.tsx
+++ b/src/components/sidemenu/SideMenu.tsx
@@ -1,10 +1,12 @@
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
-import { useEffect, useState } from 'react';
+import { doc, getDoc, getFirestore } from 'firebase/firestore';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { prefitt_logo2, sidemenu_list, sidemenu_plus } from '../../assets/assets';
 import { default as SideMenuList, default as SidemenuList } from '../../components/sidemenu/SidemenuList';
 import { useChatCompletion } from '../../hooks/useChatCompletionHook';
 import useChatHistoryHook from '../../hooks/useChatHistoryHook';
+import SideMenuSkeleton from '../sidemenu-skeleton/SideMenuSkeleton';
 import SidemenuMypageLinks from './SidemenuMypageLinks';
 import {
   logoIcon,
@@ -23,7 +25,6 @@ import {
   sidemenuNewChatContainer,
 } from './sidemenu.css';
 import { sidemenuUserProfileLogin } from './sidemenuMypageLinks.css';
-import { doc, getDoc, getFirestore } from 'firebase/firestore';
 
 type SideMenuProps = {
   onClose: () => void;
@@ -36,22 +37,29 @@ const SideMenu = ({ onClose }: SideMenuProps) => {
   const navigate = useNavigate();
   const auth = getAuth();
   const { handleNewChat } = useChatCompletion();
-  const { chatHistory, deleteChatHistory } = useChatHistoryHook();
+  const { chatHistory, deleteChatHistory, chatHistoryIsLoading } = useChatHistoryHook();
   // 현재 UTC 시간으로 오늘 날짜 계산
-  const today = new Date();
-  const utcToday = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())); // UTC 시간
+  // UTC 시간
+  const utcToday = useMemo(() => {
+    const today = new Date();
+    return new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  }, []);
+
   const sevenDaysAgo = new Date(utcToday.getTime() - 7 * 24 * 60 * 60 * 1000); // UTC 기준 7일 전 시간
-  console.log('chatHistoryData', chatHistory);
+
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
     const unsubscribe = onAuthStateChanged(auth, user => {
-      setIsLoggedIn(!!user); // 사용자가 로그인되어 있으면 true, 아니면 false
+      setIsLoggedIn(!!user);
+      if (user) {
+        setCurrentUserUid(user.uid);
+      }
     });
 
     return () => {
       document.body.style.overflow = 'auto';
-      unsubscribe(); // Firebase 인증 상태 변경 구독 해제
+      unsubscribe();
     };
   }, [auth]);
 
@@ -75,42 +83,53 @@ const SideMenu = ({ onClose }: SideMenuProps) => {
     fetchUserData();
   }, [auth]);
 
-  const handleLoginClick = () => {
-    onClose(); // 모달 닫기
-    navigate('/login'); // 로그인 페이지로 이동
-  };
-
-  const handleNavigateChatbot = async () => {
-    const newChatId = await handleNewChat();
-    navigate(`/hello/${newChatId}`);
+  const handleLoginClick = useCallback(() => {
     onClose();
-  };
+    navigate('/login');
+  }, [onClose, navigate]);
 
-  const filteredTodayChatHistory = chatHistory
-    .filter(chat => {
-      const chatDate = new Date(chat.timestamp);
-      return (
-        currentUserUid && // Firestore에서 가져온 uid가 존재할 경우에만 필터링
-        chatDate.getUTCFullYear() === utcToday.getUTCFullYear() &&
-        chatDate.getUTCMonth() === utcToday.getUTCMonth() &&
-        chatDate.getUTCDate() === utcToday.getUTCDate()
-      );
-    })
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  const handleNavigateChatbot = useCallback(async () => {
+    const newChatId = await handleNewChat();
+    navigate(`/chat/${newChatId}`);
+    onClose();
+  }, [handleNewChat, navigate, onClose]);
 
-  const filtered7DaysChatHistory = chatHistory
-    .filter(chat => {
-      const chatDate = new Date(chat.timestamp);
-      return (
-        currentUserUid && // Firestore에서 가져온 uid가 존재할 경우에만 필터링
-        chatDate > sevenDaysAgo &&
-        chatDate < utcToday && // 오늘 날짜를 제외
-        (chatDate.getUTCFullYear() !== utcToday.getUTCFullYear() ||
-          chatDate.getUTCMonth() !== utcToday.getUTCMonth() ||
-          chatDate.getUTCDate() !== utcToday.getUTCDate())
-      );
-    })
-    .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  const filteredTodayChatHistory = useMemo(() =>
+    chatHistory
+      .filter(chat => {
+        const chatDate = new Date(chat.timestamp);
+        return (
+          currentUserUid &&
+          chatDate.getUTCFullYear() === utcToday.getUTCFullYear() &&
+          chatDate.getUTCMonth() === utcToday.getUTCMonth() &&
+          chatDate.getUTCDate() === utcToday.getUTCDate()
+        );
+      })
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()),
+    [chatHistory, currentUserUid, utcToday]
+  );
+
+  const filtered7DaysChatHistory = useMemo(() =>
+    chatHistory
+      .filter(chat => {
+        const chatDate = new Date(chat.timestamp);
+        return (
+          currentUserUid &&
+          chatDate > sevenDaysAgo &&
+          chatDate < utcToday &&
+          (chatDate.getUTCFullYear() !== utcToday.getUTCFullYear() ||
+            chatDate.getUTCMonth() !== utcToday.getUTCMonth() ||
+            chatDate.getUTCDate() !== utcToday.getUTCDate())
+        );
+      })
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()),
+    [chatHistory, currentUserUid, sevenDaysAgo, utcToday]
+  );
+
+  // if (chatHistoryIsLoading) return <SideMenuSkeleton />
+
+
+
 
   return (
     <>
@@ -142,30 +161,37 @@ const SideMenu = ({ onClose }: SideMenuProps) => {
                   >
                     오늘
                   </h3>
-                  <div className={sidemenuListsItem3ScrollAuto}>
-                    <ul
-                      className={sidemenuListsBox}
-                      style={{
-                        display: filteredTodayChatHistory.length === 0 ? 'none' : 'flex',
-                      }}
-                    >
-                      {filteredTodayChatHistory.map(
-                        chat =>
-                          !deletedChatIds.includes(chat.id) && ( // 삭제된 ID가 아닐 경우에만 렌더링
-                            <SidemenuList
-                              key={chat.id}
-                              iconSrc={sidemenu_list}
-                              shareId={chat.shareId}
-                              id={chat.id}
-                              keywords={chat.keywords}
-                              timestamp={chat.timestamp}
-                              onClose={onClose}
-                              handleDelete={deleteChatHistory} // 삭제 함수 전달
-                            />
-                          )
-                      )}
-                    </ul>
-                  </div>
+                  {chatHistoryIsLoading ? (
+                    <div style={{ marginTop: '15px' }}>
+                      <SideMenuSkeleton />
+                    </div>
+
+                  ) : (
+                    <div className={sidemenuListsItem3ScrollAuto}>
+                      <ul
+                        className={sidemenuListsBox}
+                        style={{
+                          display: filteredTodayChatHistory.length === 0 ? 'none' : 'flex',
+                        }}
+                      >
+                        {filteredTodayChatHistory.map(
+                          chat =>
+                            !deletedChatIds.includes(chat.id) && ( // 삭제된 ID가 아닐 경우에만 렌더링
+                              <SidemenuList
+                                key={chat.id}
+                                iconSrc={sidemenu_list}
+                                shareId={chat.shareId}
+                                id={chat.id}
+                                keywords={chat.keywords}
+                                timestamp={chat.timestamp}
+                                onClose={onClose}
+                                handleDelete={deleteChatHistory} // 삭제 함수 전달
+                              />
+                            )
+                        )}
+                      </ul>
+                    </div>
+                  )}
                 </div>
                 <div>
                   <h3
@@ -176,35 +202,39 @@ const SideMenu = ({ onClose }: SideMenuProps) => {
                   >
                     지난 7일
                   </h3>
-                  <div className={sidemenuListsItem5ScrollAuto}>
-                    <ul
-                      className={sidemenuListsBox}
-                      style={{
-                        display: filtered7DaysChatHistory.length === 0 ? 'none' : 'flex',
-                      }}
-                    >
-                      {filtered7DaysChatHistory.map(
-                        chat =>
-                          !deletedChatIds.includes(chat.id) && ( // 삭제된 ID가 아닐 경우에만 렌더링
-                            <SideMenuList
-                              key={chat.id}
-                              iconSrc={sidemenu_list}
-                              id={chat.id}
-                              shareId={chat.shareId}
-                              keywords={chat.keywords}
-                              timestamp={chat.timestamp}
-                              handleDelete={deleteChatHistory} // 삭제 함수 전달
-                              onClose={onClose}
-                            />
-                          )
-                      )}
-                    </ul>
-                  </div>
+                  {chatHistoryIsLoading ? (
+                    <SideMenuSkeleton />
+                  ) : (
+                    <div className={sidemenuListsItem5ScrollAuto}>
+                      <ul
+                        className={sidemenuListsBox}
+                        style={{
+                          display: filtered7DaysChatHistory.length === 0 ? 'none' : 'flex',
+                        }}
+                      >
+                        {filtered7DaysChatHistory.map(
+                          chat =>
+                            !deletedChatIds.includes(chat.id) && ( // 삭제된 ID가 아닐 경우에만 렌더링
+                              <SideMenuList
+                                key={chat.id}
+                                iconSrc={sidemenu_list}
+                                id={chat.id}
+                                shareId={chat.shareId}
+                                keywords={chat.keywords}
+                                timestamp={chat.timestamp}
+                                handleDelete={deleteChatHistory} // 삭제 함수 전달
+                                onClose={onClose}
+                              />
+                            )
+                        )}
+                      </ul>
+                    </div>
+                  )}
                 </div>
               </article>
             </>
           ) : (
-            <></>
+            null
           )}
           {/* mypage 링크 또는 로그인 버튼 */}
           <article className={sidemenuMypageMoveContainer}>

--- a/src/components/sidemenu/SidemenuList.tsx
+++ b/src/components/sidemenu/SidemenuList.tsx
@@ -90,7 +90,7 @@ const SideMenuList = ({ iconSrc, keywords, id, shareId, handleDelete, onClose }:
   const navigate = useNavigate();
   const handleChatLink = async () => {
     setCurrentChatId(id);
-    navigate(`/hello/${id}`);
+    navigate(`/chat/${id}`);
     onClose()
   };
 

--- a/src/components/signup/sizeinput/SignUpSizeModal.tsx
+++ b/src/components/signup/sizeinput/SignUpSizeModal.tsx
@@ -95,7 +95,7 @@ const SignUpSizeModal: React.FC<SignUpSizeModalProps> = ({ isOpen, onClose }) =>
         const newChatId = await handleNewChat();
 
         onClose();
-        navigate(`/hello/${newChatId}`, { replace: true });
+        navigate(`/chat/${newChatId}`, { replace: true });
       } catch {
         // console.error('사용자 등록 실패:', error);
         setToastMessage({ message: '다시 시도해 주세요.', duration: 3000 });

--- a/src/index.css.ts
+++ b/src/index.css.ts
@@ -39,13 +39,12 @@ globalStyle('ul,li,ol', {
 
 globalStyle('body', {
   minHeight: '100dvh',
-  lineHeight: '1',
   backgroundColor: theme.color.slate200,
   overflow: 'hidden',
 });
 
 globalStyle('h1,h2,h3,h4,button,input,label', {
-  lineHeight: '1.1',
+  lineHeight: '1.4em',
 });
 
 globalStyle('h1,h2,h3,h4,b', {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 import './index.css.ts';
 import { router } from './router/index.tsx';
@@ -12,6 +13,6 @@ createRoot(document.getElementById('root')!).render(
     <StrictMode>
       <RouterProvider router={router} />
     </StrictMode>
-    {/* <ReactQueryDevtools initialIsOpen={false} /> */}
+    <ReactQueryDevtools initialIsOpen={false} />
   </QueryClientProvider>
 );

--- a/src/pages/not-found/notFound.css.ts
+++ b/src/pages/not-found/notFound.css.ts
@@ -3,7 +3,7 @@ import { theme } from '../../styles/theme';
 
 export const notFoundWrap = style({
   width: '100%',
-  height: '100%',
+  height: '100vh',
   backgroundColor: theme.color.black900,
   display: 'flex',
   justifyContent: 'center',

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -75,7 +75,7 @@ export const router = createBrowserRouter([
         element: <Login />,
       },
       {
-        path: '/hello/:chatId?',
+        path: '/chat/:chatId?',
         element: <LoginHello />,
       },
       {

--- a/src/utils/bridgePageUtils.ts
+++ b/src/utils/bridgePageUtils.ts
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 // bridgePageUtils.js
 export const useBridgePage = (showBridgePage:boolean, selectedProductLink:string) => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     let timer: NodeJS.Timeout;
     if (showBridgePage && selectedProductLink) {
       timer = setTimeout(() => {
-        window.location.href = selectedProductLink;
+        navigate(selectedProductLink);
       }, 1000);
     }
     return () => clearTimeout(timer);
-  }, [showBridgePage, selectedProductLink]);
+  }, [showBridgePage, selectedProductLink, navigate]);
 };

--- a/src/utils/resizeImageUtils.ts
+++ b/src/utils/resizeImageUtils.ts
@@ -1,0 +1,38 @@
+import Resizer from 'react-image-file-resizer';
+
+export const resizeImage = (file: File, maxWidth: number = 800, maxHeight: number = 800, quality: number = 100): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    // 원본 이미지 크기 확인
+    const img = new Image();
+    img.onload = () => {
+      const originalWidth = img.width;
+      const originalHeight = img.height;
+
+      // 원본 이미지가 이미 maxWidth와 maxHeight보다 작은 경우
+      if (originalWidth <= maxWidth && originalHeight <= maxHeight) {
+        // 원본 이미지를 그대로 반환
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      } else {
+        // 리사이징 필요한 경우
+        Resizer.imageFileResizer(
+          file,
+          maxWidth,
+          maxHeight,
+          'WEBP',
+          quality,
+          0,
+          (uri) => {
+            // console.log('Resized image URI:', uri);
+            resolve(uri as string);
+          },
+          'base64'
+        );
+      }
+    };
+    img.onerror = reject;
+    img.src = URL.createObjectURL(file);
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,6 +2935,11 @@ react-hook-form@^7.53.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.53.0.tgz#3cf70951bf41fa95207b34486203ebefbd3a05ab"
   integrity sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==
 
+react-image-file-resizer@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz#85f4ae4469fd2867d961568af660ef403d7a79af"
+  integrity sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ==
+
 react-markdown@^9.0.1:
   version "9.0.1"
   resolved "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.1.tgz"


### PR DESCRIPTION
### 🌎Pull Request
> ### Title
> * [refactor] 사이드메뉴 스캘래톤 생성, 이미지 검색시 포맷,리사이징

> ### #️⃣연관되어 있는 이슈
> ex) #174 

> ### PR Type
  > - [ ] FEAT :sparkles:: 새로운 기능 구현
  > - [ ] ADD :bento:: 에셋 파일 추가
  > - [ ] FIX :bug:: 버그 수정
  > - [ ] DOCS :memo:: 문서 추가 및 수정
  > - [ ] STYLE :lipstick:: UI, 스타일 관련 파일 추가 및 수정
  > - [x] REFACTOR :recycle:: 코드 리팩토링
  > - [ ] TEST :clown_face:: 테스트 관련
  > - [ ] DEPLOY :rocket:: 배포 관련
  > - [ ] CONF :green_heart:: 빌드, 환경 설정
  > - [ ] CHORE :adhesive_bandage:: 기타 작업

> ### Description
> * 이미지 리사이징 함수 생성
> * 사이드메뉴 날짜연산 useMemo, useCallback사용 리팩토링
> * Path /hello -> /chat 으로 변경
> * 404 페이지 높이값 100vh
> * useChatHistoryHook.ts 코드 리팩토링
> * 글로벌 css 줄간격 1 -> 1.4em 변경
> * bridgePageUtils.ts 코드 리팩토링

> ### Screenshot
> * https://github.com/user-attachments/assets/8765e157-ce26-42e8-91a3-e1ad6e2def92
> ### Discussion
> * API를 통해서 외부 이미지 받아오는건 webp로 변환이 안되는것같음... 이미지가 최대페인트 요소라 loading="lazy" 넣어도 큰 변화가 없어보임
